### PR TITLE
Fix port mapping name is already used

### DIFF
--- a/ecs/ops.tf
+++ b/ecs/ops.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_task_definition" "ops" {
             "appProtocol" : "http"
           },
           {
-            "name" : "http",
+            "name" : "admin",
             "protocol" : "tcp",
             "containerPort" : 9085,
             "appProtocol" : "http"


### PR DESCRIPTION
Fixes;
```sh
Error: creating ECS Task Definition (XXX-ops): ClientException: When networkMode=awsvpc, port mapping name is already used
```