### PR TITLE
Fix deprecated attributes

### DIFF
--- a/ecs/ecs.tf
+++ b/ecs/ecs.tf
@@ -1,14 +1,17 @@
 resource "aws_ecs_cluster" "this" {
   name = var.project
 
-  capacity_providers = [
-    "FARGATE",
-    "FARGATE_SPOT"
-  ]
-
   tags = {
     Name = "${var.project}"
   }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name       = aws_ecs_cluster.this.name
+  capacity_providers = [
+    "FARGATE",
+    "FARGATE_SPOT",
+  ]
 }
 
 resource "aws_ecs_task_definition" "this" {

--- a/rds/db_instance.tf
+++ b/rds/db_instance.tf
@@ -19,7 +19,7 @@ resource "aws_db_instance" "main" {
   max_allocated_storage                 = "1000"
   monitoring_interval                   = "0"
   multi_az                              = "false"
-  name                                  = "quickstart"
+  db_name                               = "quickstart"
   option_group_name                     = "default:mysql-8-0"
   parameter_group_name                  = "default.mysql8.0"
   performance_insights_enabled          = "false"

--- a/vpc/vpc.tf
+++ b/vpc/vpc.tf
@@ -1,7 +1,5 @@
 resource "aws_vpc" "main" {
   cidr_block                       = "10.0.0.0/16"
-  enable_classiclink               = false
-  enable_classiclink_dns_support   = false
   enable_dns_hostnames             = true
   enable_dns_support               = true
   instance_tenancy                 = "default"


### PR DESCRIPTION
Uses terraform `v1.5.1`

 
 ```sh
│ Warning: Argument is deprecated
│ 
│   with module.ecs.aws_ecs_cluster.this,
│   on ecs/ecs.tf line 4, in resource "aws_ecs_cluster" "this":
│    4:   capacity_providers = [
│    5:     "FARGATE",
│    6:     "FARGATE_SPOT"
│    7:   ]
│ 
│ Use the aws_ecs_cluster_capacity_providers resource instead
│ 
│ (and 7 more similar warnings elsewhere)

╷
│ Warning: Argument is deprecated
│ 
│   with module.rds.aws_db_instance.main,
│   on rds/db_instance.tf line 22, in resource "aws_db_instance" "main":
│   22:   name                                  = "quickstart"
│ 
│ Use db_name instead
│ 
│ (and 5 more similar warnings elsewhere)
╵

╷
│ Warning: Argument is deprecated
│ 
│   with module.vpc.aws_vpc.main,
│   on vpc/vpc.tf line 3, in resource "aws_vpc" "main":
│    3:   enable_classiclink               = false
│ 
│ With the retirement of EC2-Classic the enable_classiclink attribute has been deprecated and will be removed in a future version.
│ 
│ (and 3 more similar warnings elsewhere)

╷
│ Warning: Argument is deprecated
│ 
│   with module.vpc.aws_vpc.main,
│   on vpc/vpc.tf line 3, in resource "aws_vpc" "main":
│    3:   enable_classiclink_dns_support   = false
│ 
│ With the retirement of EC2-Classic the enable_classiclink_dns_support attribute has been deprecated and will be removed in a future version.
│ 
│ (and one more similar warning elsewhere)
╵
```